### PR TITLE
Added Makefile for script integration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,3 @@
+
+all: wgsim.c kseq.h
+	gcc -g -O2 -Wall -o wgsim wgsim.c -lz -lm 


### PR DESCRIPTION
I wrote a script to automate aligner testing that depends on Makefiles in github repos.
Why not have one instead of listing recommended compile flags in README?